### PR TITLE
Installation scripts (my take)

### DIFF
--- a/examples/format_example.modip.json
+++ b/examples/format_example.modip.json
@@ -110,6 +110,28 @@
           ]
         }
       ],
+      "installation": [
+        {
+          "type": "framework_fork",
+          "framework_steps": {
+            "framework-fabric-loader": [
+              {
+                "type": "placeInDirectory",
+                "directory": "mods",
+                "file": "1.0.0-fabric.jar"
+              }
+            ],
+            "framework-forge": [
+              {
+                "type": "placeInDirectory",
+                "directory": "mods",
+                "file": "1.0.0-forge.jar"
+              }
+            ]
+          },
+          "preferred": "framework-fabric-loader"
+        }
+      ],
       "files": [
         {
           "rel": "primary",
@@ -122,10 +144,6 @@
               "version": ">= 0.9.0"
             }
           ],
-          "installation": {
-            "method": "placeInDirectory",
-            "directory": "mods"
-          },
           "downloads": [
             "https://example.com/download/1.0.0-fabric.jar"
           ]
@@ -141,10 +159,6 @@
               "version": ">= 32.0.106"
             }
           ],
-          "installation": {
-            "method": "placeInDirectory",
-            "directory": "mods"
-          },
           "downloads": [
             "https://example.com/download/1.0.0-forge.jar"
           ]

--- a/examples/format_example.modip.json
+++ b/examples/format_example.modip.json
@@ -134,7 +134,6 @@
       ],
       "files": [
         {
-          "rel": "primary",
           "name": "1.0.0-fabric.jar",
           "sha256": "< sum goes here >",
           "dependencies": [
@@ -149,7 +148,6 @@
           ]
         },
         {
-          "rel": "primary",
           "name": "1.0.0-forge.jar",
           "sha256": "< sum goes here >",
           "dependencies": [

--- a/examples/format_example_fabric_intermediary.modip.json
+++ b/examples/format_example_fabric_intermediary.modip.json
@@ -55,13 +55,19 @@
       "name": "Intermediary 1.16.1",
       "releaseDate": "2020-08-05T20:59:00Z",
       "changelog": "Intermediary changelog goes here...",
-      "installation": {
-        "method": "classpathLibrary",
-        "versionJson": {
-          "name": "net.fabricmc:intermediary:1.16.1",
-          "url": "https://maven.fabricmc.net"
+      "installation": [
+        {
+          "type": "addClasspathLibrary",
+          "library": {
+            "name": "net.fabricmc:intermediary:1.16.1",
+            "downloads": {
+              "artifact": {
+                "modip_filename": "intermediary-1.16.1.jar"
+              }
+            }
+          }
         }
-      },
+      ],
       "dependencies": [
         {
           "id": "minecraft",

--- a/examples/format_example_fabric_loader.modip.json
+++ b/examples/format_example_fabric_loader.modip.json
@@ -55,9 +55,38 @@
       "name": "Release 0.9.0+build.204",
       "releaseDate": "2020-08-05T20:59:00Z",
       "changelog": "Fabric version changelog goes here...",
-      "installation": {
-        "method": "versionJsonInstall"
-      },
+      "installation": [
+        {
+          "type": "addClasspathLibrary",
+          "library": {
+            "name": "net.fabricmc:tiny-mappings-parser:0.2.2.14",
+            "downloads": {
+              "artifact": {
+                "sha1": "<sum goes here>",
+                "size": 12345678,
+                "url": "https://maven.fabricmc.net/net/fabricmc/tiny-mappings-parser/tiny-mappings-parser-0.2.2.14.jar"
+              }
+            }
+          }
+        },
+        {
+          "type": "addClasspathLibrary",
+          "library": {
+            "name": "net.fabricmc:fabric-loader:0.9.0+build.204",
+            "downloads": {
+              "artifact": {
+                "modip_filename": "fabric-loader-0.9.0+build.204.jar"
+              }
+            }
+          }
+        },
+        {"_comment": "and all the rest of Fabric's required libraries - there are 12 in total"},
+        {
+          "type": "setMainClass",
+          "from": ["net.minecraft.client.main.Main"],
+          "to": "net.fabricmc.loader.launch.knot.KnotClient"
+        }
+      ],
       "dependencies": [
         {
           "id": "minecraft",
@@ -72,10 +101,10 @@
       "files": [
         {
           "rel": "versionJson",
-          "name": "profile.json",
+          "name": "fabric-loader-0.9.0+build.204.jar",
           "sha256": "< sum goes here >",
           "downloads": [
-            "https://meta.fabricmc.net/v2/versions/loader/1.16.1/0.9.0+build.204/profile/json"
+            "https://maven.fabricmc.net/net/fabricmc/fabric-loader/0.9.0+build.204/fabric-loader-0.9.0+build.204.jar"
           ]
         }
       ]

--- a/examples/format_example_modpack.modip.json
+++ b/examples/format_example_modpack.modip.json
@@ -133,12 +133,27 @@
           "version": "6.2.1"
         }
       ],
-      "installation": {
-        "method": "instanceInstall"
-      },
+      "installation": [
+        {
+          "type": "client_server_fork",
+          "client_steps": [
+            {
+              "type": "extractZip",
+              "directory": ".",
+              "file": "overrides.zip"
+            }
+          ],
+          "server_steps": [
+            {
+              "type": "extractZip",
+              "directory": ".",
+              "file": "overrides-server.zip"
+            }
+          ]
+        }
+      ],
       "files": [
         {
-          "rel": "compressedOverrides",
           "name": "overrides.zip",
           "sha256": "< sum goes here >",
           "downloads": [
@@ -153,7 +168,6 @@
           ]
         },
         {
-          "rel": "compressedOverrides",
           "name": "overrides-server.zip",
           "sha256": "< sum goes here >",
           "downloads": [

--- a/examples/format_example_modpack.modip.json
+++ b/examples/format_example_modpack.modip.json
@@ -173,12 +173,6 @@
           "downloads": [
             "https://example.com/download/oevrrides.zip"
           ],
-          "allowed": {
-            "environment": {
-              "client": false,
-              "server": true
-            }
-          },
           "_comment": [
             "This file is only allowed on a server"
           ]

--- a/format_spec.md
+++ b/format_spec.md
@@ -320,6 +320,10 @@ If not all information is listed inside a dependency object and it's metadata is
 The required Minecraft Version also MUST be stored as a dependency. It's `id` value MUST be set to `minecraft`. It also MUST not contain the `required` field, as Minecraft is not an optional component.
 A dependencies implementation guide for launchers is available in **format_implementing.md**.
 
+##### `installation`
+
+The installation script for this version. For details about installation scripts, see `install_script.md`.
+
 ---
 
 ### `files`
@@ -342,18 +346,6 @@ The relation of this file. Possible values for this field are available in **for
 ##### `dependencies` (optional)
 
 This field MUST conform to the same specification as the Version's dependencies. BOTH a File and Version can have dependencies.
-
-##### `installation`
-
-The installation method of this file. This MUST be stored as an object. The object MUST contain the field `method`. Information on the possible values in the installation object is [currently available as a Pull Request](https://github.com/modip-org/spec/pull/2).
-
-The installation field CAN be present for BOTH Version and File Objects, similar to `dependencies`. The installation method in the file will override the installation method in the version if present.
-
-If the installation field is present in the Version, it is not required in the file. If it's NOT present in the version, it MUST be present for the file. The per-version installation field exists for Frameworks to avoid unnecessary fields and to be clearer about how a version should be installed. For an example Framework in the MODIP format, please view **examples/format_example_fabric_loader.json**.
-
-##### `allowed` (optional)
-
-Specifies whether this file is allowed to be installed. Used in conjunction with Conditions. **This field MAY be a condition.**
 
 ##### `downloads`
 

--- a/install_script.md
+++ b/install_script.md
@@ -1,6 +1,6 @@
 # Install script
 
-An install script is a fragment of data which describes how to install a mod.
+An install script is a fragment of data which describes how to install a project.
 
 Each version of a project can have a different install script.
 
@@ -8,6 +8,35 @@ An install script consists of a *list* of steps referencing the files in the ver
 
 Example:
 `[{"type": "placeInDirectory", "directory": "mods", "file": "ExampleMod-1.0.0.jar"}, {"type": "placeInDirectory", "directory": "coremods", "file": "ExampleMod-1.0.0-coremod.jar"}]`
+
+## `depends`/`conflicts`/`recommends` step
+
+`depends` means the referenced project is required for this one to work correctly.  
+`conflicts` means this project does not work alongside the referenced one.  
+`recommends` means this project interoperates with the referenced one. This is not binding.
+
+Attempting to install a project without a dependency should install the dependency, or prompt the user to install it.  
+Attempting to install a project that conflicts with an already-installed one should prompt the user to uninstall it.  
+Expert users should have the option to ignore both problems, and install the project anyway.
+
+Finding a set of dependencies which do not conflict is, in the general case, equivalent to solving the Boolean satisfiability problem ("SAT").
+Installers are not required to include SAT solvers, since dependencies and conflicts are advisory. If the user wants to install a set of projects, and an "obvious" solution does not work (e.g. latest version of each), then the installer may leave it up to the user to find a set of versions which works, instead of spending significant computational time trying to find a solution. Installers are permitted to include additional heuristics.
+
+Example:
+`[{"type": "depends", "id": "cofh-core", "version": ">=1.2.3.4", "url": "https://example.com/modip/cofh-core.json"}]`
+
+### `id`
+
+The ID of the required dependency. ~If this project is a Framework, it MUST be one of the values listed in **format_values.md** for Framework IDs. Hosts serving Framework metadata MUST use these standardized IDs.~
+
+### `required`
+
+This field is a boolean that indicates whether a dependency is required in order for the Project requiring it to function properly. **MAY be a condition.**
+
+### `version`
+
+This field MUST be either an Array or String. If this field is an array, it MUST contain a list of compatible versions. If this field is a String, it MUST contain a Semantic Versioning comparison String. An example of a comparison string is `>= 25.0.219`.
+
 
 ## `placeInDirectory` step
 
@@ -49,7 +78,8 @@ Download a file and add it to the classpath.
 
 Inside the "library" field is an object identical to Minecraft's version.json library specification,
 except that wherever there is a `sha1`/`size`/`url` triplet in Mojang's format, the install script
-MAY instead contain a `modip_filename` which refers to one of the version's files.
+MAY instead contain a `modipFilename` which refers to one of the version's files. (If the installer generates a file for Minecraft's launcher,
+then it must fill in the `sha1`/`size`/`url` based on the named file)
 
 (Third-party libraries should still include `sha1`/`size`/`url` to download from the Internet - they shouldn't be republished as part of the mod version)
 
@@ -68,7 +98,7 @@ Example:
             },
             "classifiers": {
                 "natives-osx": {
-                    "modip_filename": "MyLibrary-natives-osx.jar"
+                    "modipFilename": "MyLibrary-natives-osx.jar"
                 }
             }
         },
@@ -109,6 +139,8 @@ Example:
 
 `from` specifies what the main class should have been before. If multiple actions of this type are executed (from multiple mods), they must be linked in a chain, starting from the vanilla's main class, and then the last step in the chain indicates the actual main class. If they can't be linked in a chain, the installed mods are not compatible. `from` must be a list. The previous main class must match any value in the list.
 
+It may be assumed that the chain does not contain loops.
+
 ## Client/server fork step
 
 Uses a different installation method on the client than on the server.
@@ -117,38 +149,48 @@ Example:
 
 ```
 {
-    "type": "client_server_fork",
-    "client_steps": [
+    "type": "clientServerFork",
+    "clientSteps": [
     ],
-    "server_steps": [
+    "serverSteps": [
     ]
 }
 ```
 
 Note: `client_steps` and `server_steps` are always lists, and must be present even if empty.
 
-## Framework fork step
+## Generic fork step
 
-Allows a mod to support multiple mod loaders.
+Allows a mod to support multiple dependency sets, such as different mod loaders.
 
 ```
 {
-    "type": "framework_fork",
-    "framework_steps": {
-        "<framework id>": [
-        ],
-        "<other framework id>": [
-        ]
-    },
-    "preferred": "<framework id>"
+    "type": "fork",
+    "id": "<fork id>",
+    "branches": {
+        "<id 1>": {
+            "label": "<label 1>",
+            "steps": [
+            ]
+        },
+        "<id 2>": {
+            "label": "<label 2>",
+            "steps": [
+            ]
+        }
+    }
 }
 ```
 
-Note: values in `framework_steps` are always lists, and must be present even if empty.
-If no entry is present for the current framework, the mod is incompatible with it.
-If the current framework is unknown (i.e. no mods are installed yet), the launcher should install the one in `preferred` (which must be one of the options).
-If *multiple* supported frameworks are present (i.e. Patchwork), the launcher MAY choose a preferred one, ask the user, or give up (fall back to manual installation).
+Note: One entry *must* be chosen. If you want an empty option, you must write it explicitly.
 
-If this mechanism is used to support multiple frameworks, neither framework should be listed as a dependency, as that would require it to be installed!
+The installer should ask the user which branch to take. If exactly one branch is valid for the current installation (based on dependency and conflict information), the installer may skip the question.
 
-Design note: Using a "fork" step instead of a conventional "if" step allows the launcher to and choose a framework if none is installed yet.
+When the version of a project is changed, the IDs may be used to (with best effort) transfer the previous fork selection to the new version.
+Fork IDs are scoped to a project - not only a version. Branch IDs are scoped to a fork - different forks may use the same branch IDs, with no consequence.
+
+Any particular "execution" of the script must not encounter two forks with the same ID. If this occurs, the behaviour is unspecified. Fork IDs may be reused on disjoint code paths - for example, in both branches of an outer fork.
+
+One branch must be taken. It is not valid for an installer to take no branch. If all branches are invalid because of dependencies or conflicts, the mod can't be installed without overriding them. If it is valid to not take a branch, an explicit empty branch must be included. Note that even an empty branch must still contain `"steps": []`
+
+Design note: Using a "fork" step instead of a conventional "if" step allows the launcher to enumerate all valid configurations.

--- a/install_script.md
+++ b/install_script.md
@@ -1,0 +1,154 @@
+# Install script
+
+An install script is a fragment of data which describes how to install a mod.
+
+Each version of a project can have a different install script.
+
+An install script consists of a *list* of steps referencing the files in the version.
+
+Example:
+`[{"type": "placeInDirectory", "directory": "mods", "file": "ExampleMod-1.0.0.jar"}, {"type": "placeInDirectory", "directory": "coremods", "file": "ExampleMod-1.0.0-coremod.jar"}]`
+
+## `placeInDirectory` step
+
+Download a file into a subdirectory of the Minecraft instance directory.
+
+Example:
+
+`{"type": "placeInDirectory", "directory": "mods", "file": "ExampleMod-1.0.0.jar"}`
+
+`directory` may be a nested subdirectory, e.g. `"mods/1.7.10"`. Any parent directories which don't already exist are created.
+`directory` may not contain a `.` or `..` part, unless the entire value of `directory` is `"."` (which places the file in the instance directory).
+
+## `extractZip` step
+
+Download a file *and extract it* into a subdirectory of the Minecraft instance directory.
+
+Example:
+
+`{"type": "extractZip", "directory": "config", "file": "modpack-configs.zip"}`
+
+`directory` may be a nested subdirectory, e.g. `"mods/1.7.10"`. Any parent directories which don't already exist are created.
+`directory` may not contain a `.` or `..` part, unless the entire value of `directory` is `"."` (which extracts the file into the instance directory).
+
+## `jarMod` step
+
+Download a file and merge it into `minecraft.jar` (or `minecraft-server.jar`), overwriting files that already exist.
+
+Note: this is considered an obsolete installation technique. Newer loaders typically add themselves to the classpath instead.
+
+`before` and `after` allow this project's jar mod to be prioritized when multiple jar mods are present. If a mod mentioned in `before` or `after`
+is not installed, this does not cause it to be installed - the entry does nothing.
+
+Example:
+`{"type": "jarMod", "file": "modloadermp-1.0.0.jar", "before": ["minecraft-forge"], "after": ["modloader"]}`
+
+## `addClasspathLibrary` step
+
+Download a file and add it to the classpath.
+
+Inside the "library" field is an object identical to Minecraft's version.json library specification,
+except that wherever there is a `sha1`/`size`/`url` triplet in Mojang's format, the install script
+MAY instead contain a `modip_filename` which refers to one of the version's files.
+
+(Third-party libraries should still include `sha1`/`size`/`url` to download from the Internet - they shouldn't be republished as part of the mod version)
+
+TODO: Mojang sometimes changes this format. We should pin it down to a particular version.
+
+Example:
+
+```
+{
+    "type": "addClasspathLibrary",
+    "library": {
+        "name": "com.me.mylibrary:mylibrary:1.2.3",
+        "downloads": {
+            "artifact": {
+                "modip_filename": "MyLibrary-common.jar"
+            },
+            "classifiers": {
+                "natives-osx": {
+                    "modip_filename": "MyLibrary-natives-osx.jar"
+                }
+            }
+        },
+        "natives": {
+            "osx": "natives-osx"
+        },
+        "rules": [
+            {"action": "allow", "os": {"name": "osx"}}
+        ]
+    },
+    "before": ["com.othercorp.otherlibrary:otherlibrary"],
+    "after": ["com.thirdcorp.thirdlibrary:thirdlibrary:1.2"]
+}
+```
+
+`before` and `after` allow this project's classpath library to be prioritized when multiple classpath libraries are present. If a library mentioned in `before` or `after` is not installed, this does not cause it to be installed - the entry does nothing. In `before` and `after` entries, the group ID and artifact ID are mandatory, but the version is optional (if not present then it matches all versions). Versions are an exact match.
+
+`name` must contain exactly a group ID, artifact ID, and version number.
+
+MODIP and non-MODIP (e.g. Mojang) libraries are all considered together for sorting. i.e. you may request to install a library before one Mojang library and after another.
+
+This example library is only required on OSX. On other platforms, this install step is a no-op.
+The launcher MAY still download the OSX natives and add the library entry, with the OSX-only rule, in case the instance is later moved to a computer running OSX.
+
+## `setMainClass` step
+
+Updates the main class. Mainly used by loaders and standalone mods.
+
+Example:
+
+```
+{
+    "type": "setMainClass",
+    "from": ["net.minecraft.client.main.Main"],
+    "to": "net.fabricmc.loader.launch.knot.KnotClient"
+}
+```
+
+`from` specifies what the main class should have been before. If multiple actions of this type are executed (from multiple mods), they must be linked in a chain, starting from the vanilla's main class, and then the last step in the chain indicates the actual main class. If they can't be linked in a chain, the installed mods are not compatible. `from` must be a list. The previous main class must match any value in the list.
+
+## Client/server fork step
+
+Uses a different installation method on the client than on the server.
+
+Example:
+
+```
+{
+    "type": "client_server_fork",
+    "client_steps": [
+    ],
+    "server_steps": [
+    ]
+}
+```
+
+Note: `client_steps` and `server_steps` are always lists, and must be present even if empty.
+
+## Framework fork step
+
+Allows a mod to support multiple mod loaders.
+
+```
+{
+    "type": "framework_fork",
+    "framework_steps": {
+        "<framework id>": [
+        ],
+        "<other framework id>": [
+        ]
+    },
+    "preferred": "<framework id>"
+}
+```
+
+Note: values in `framework_steps` are always lists, and must be present even if empty.
+If no entry is present for the current framework, the mod is incompatible with it.
+If the current framework is unknown (i.e. no mods are installed yet), the launcher should install the one in `preferred` (which must be one of the options).
+If *multiple* supported frameworks are present (i.e. Patchwork), the launcher MAY choose a preferred one, ask the user, or give up (fall back to manual installation).
+
+If this mechanism is used to support multiple frameworks, neither framework should be listed as a dependency, as that would require it to be installed!
+
+Design note: Using a "fork" step instead of a conventional "if" step allows the launcher to and choose a framework if none is installed yet.


### PR DESCRIPTION
* Define installation scripts
* Update examples (in the case of Fabric Loader, it has 12 libraries, so I only show 2)

Not covered:
* Updating JSON schema
* Perhaps version.json is a good idea for Fabric Loader, even if we can technically do without it.
* Deciding how different dependencies work with framework_fork. For now, I left them on the files.
* What is a framework, anyway?

I wonder if dependencies could go in the installation script - then, they could be different on each side of a fork. (Putting important metadata in a script is less scary than it sounds, since it's not a real script)

Note that someone who downloads Fabric Loader expects to get Fabric Loader, not a JSON file. Maybe Fabric will have a self-contained installer eventually?