### PR TITLE
Multi-file Zips

### DIFF
--- a/format_implementing.md
+++ b/format_implementing.md
@@ -66,8 +66,11 @@ If your program considers itself a client, the mod is required. If your program 
 
 ---
 
-## Multi-file zips
+## Multifile zips
 Users may want to import a MODIP multifile zip. This zip contains a root file, `index.modip.json` which contains metadata about the project, which is likely to be a modpack/instance. Parse the project the same way you would as a normal project, except that when encountering a file name, check to see if it exists in the zip. If you encounter a file with the `name` field set to `overrides.zip`, check for a file named `overrides.zip` inside the multifile zip. If you find one and it's hash matches succesfully, you don't need to download it from the files `downloads` array.
+
+Implementation of multifile zips is **not required**. You only need to support multifile zips if you would like users to be able to import modpacks from a zip. 
+
 ## Implementing `game`
 When parsing a version of a project, the `game` field specifies which Minecraft version it's compatible with.
 

--- a/format_implementing.md
+++ b/format_implementing.md
@@ -69,3 +69,8 @@ Another condition you may see often is `required`
 ```
 
 If your program considers itself a client, the mod is required. If your program considers itself a server, the mod is not required to be installed.
+
+---
+
+## Multi-file zips
+Users may want to import a MODIP multifile zip. This zip contains a root file, `index.modip.json` which contains metadata about the project, which is likely to be a modpack/instance. Parse the project the same way you would as a normal project, except that when encountering a file name, check to see if it exists in the zip. If you encounter a file with the `name` field set to `overrides.zip`, check for a file named `overrides.zip` inside the multifile zip. If you find one and it's hash matches succesfully, you don't need to download it from the files `downloads` array.

--- a/format_spec.md
+++ b/format_spec.md
@@ -2,7 +2,7 @@
 
 This document provides detailed information on the MODIP Format.
 
-The MODIP format uses JSON to store information. If providing an API that returns format-compliant information, the `application/json` Content-Type header SHOULD be provided. If stored on disk, the `.modip.json` extension SHOULD be used.
+The MODIP format uses JSON to store information. If providing an API that returns format-compliant information, the `application/json` Content-Type header SHOULD be provided. If stored on disk, the `.modip.json` extension SHOULD be used. For storage on disk of modpacks/instances, see "Storing multiple files in one zip" at the end.
 
 A format-compliant example is provided in **examples/format_example.modip.json**.
 
@@ -393,3 +393,26 @@ The most obvious use of Conditions is for specifying client and server side mods
 See **format_values.md** for the list of conditions and groups.
 
 For information on how to implement conditions in a launcher, see **format_implementing.md**.
+
+---
+
+## Storing multiple files in one zip
+
+It's useful to be able to store a collection of multiple projects inside one zip file. The most obvious example of this is for storing modpacks. To properly store multiple in one zip, the proper architecture as listed below should be used:
+
+```
+my_modpack.zip/
+  index.modip.json
+```
+
+The metadata for the project should be stored inside `index.modip.json`. The file's name MUST be `index.modip.json`, otherwise clients will have no idea where to look for proejct metadata.
+
+What if you want to store other files, like an overrides zip for a modpack? That can be done by simply storing the file, with it's name matching the `name` field in `version.files`.
+
+```
+my_modpack.zip/
+  index.modip.json
+  overrides.zip
+```
+
+While reading the project's metadata, clients will notice the file `overrides.zip`, and then check for it inside the parent zip file. If it's found, then it will use the local `overrides.zip` instead of trying to download one from a URL specified in `file.downloads`. Because of this, you MAY leave the `downloads` array blank, but it is still recommended to provide download URLs if possible.

--- a/format_spec.md
+++ b/format_spec.md
@@ -2,7 +2,7 @@
 
 This document provides detailed information on the MODIP Format.
 
-The MODIP format uses JSON to store information. If providing an API that returns format-compliant information, the `application/json` Content-Type header SHOULD be provided. If stored on disk, the `.modip.json` extension SHOULD be used. For storage on disk of modpacks/instances, see "Storing multiple files in one zip" at the end.
+The MODIP format uses JSON to store information. If providing an API that returns format-compliant information, the `application/json` Content-Type header SHOULD be provided. If stored on disk, the `.modip.json` extension SHOULD be used. For storage on disk of modpacks/instances, see **multifile_zips.md**.
 
 A format-compliant example is provided in **examples/format_example.modip.json**.
 
@@ -416,26 +416,3 @@ The most obvious use of Conditions is for specifying client and server side mods
 See **format_values.md** for the list of conditions and groups.
 
 For information on how to implement conditions in a launcher, see **format_implementing.md**.
-
----
-
-## Storing multiple files in one zip
-
-It's useful to be able to store a collection of multiple projects inside one zip file. The most obvious example of this is for storing modpacks. To properly store multiple in one zip, the proper architecture as listed below should be used:
-
-```
-my_modpack.zip/
-  index.modip.json
-```
-
-The metadata for the project should be stored inside `index.modip.json`. The file's name MUST be `index.modip.json`, otherwise clients will have no idea where to look for proejct metadata.
-
-What if you want to store other files, like an overrides zip for a modpack? That can be done by simply storing the file, with it's name matching the `name` field in `version.files`.
-
-```
-my_modpack.zip/
-  index.modip.json
-  overrides.zip
-```
-
-While reading the project's metadata, clients will notice the file `overrides.zip`, and then check for it inside the parent zip file. If it's found, then it will use the local `overrides.zip` instead of trying to download one from a URL specified in `file.downloads`. Because of this, you MAY leave the `downloads` array blank, but it is still recommended to provide download URLs if possible.

--- a/multifile_zips.md
+++ b/multifile_zips.md
@@ -1,0 +1,23 @@
+# Multifile zips
+
+It's useful to be able to store a collection of multiple projects inside one zip file. The most obvious example of this is for storing modpacks. To properly store multiple in one zip, the proper architecture as listed below should be used:
+
+```
+my_modpack.zip/
+  index.modip.json
+```
+
+The metadata for the project should be stored inside `index.modip.json`. The file's name MUST be `index.modip.json`, otherwise clients will have no idea where to look for proejct metadata.
+
+What if you want to store other files, like an overrides zip for a modpack? That can be done by simply storing the file, with it's name matching the `name` field in `version.files`.
+
+```
+my_modpack.zip/
+  index.modip.json
+  overrides.zip
+```
+
+While reading the project's metadata, clients will notice the file `overrides.zip`, and then check for it inside the parent zip file. If it's found, then it will use the local `overrides.zip` instead of trying to download one from a URL specified in `file.downloads`. Because of this, you MAY leave the `downloads` array blank, but it is still recommended to provide download URLs if possible.
+
+## Why?
+This is most useful for modpacks. If you'd like to send a modpack to a friend, for example, multifile zips are the best way to do it. They keep the entire pack in one file, and allow bundling of other files within them, making implementation easier.


### PR DESCRIPTION
Improves modpacks by allowing for multiple files to be in one zip, and specifies the proper structure of a MODIP zip. Will be useful with #8.