### PR TITLE
Dependency rework

### DIFF
--- a/format_implementing.md
+++ b/format_implementing.md
@@ -21,6 +21,13 @@ When looking at a dependency, the first thing to do is check for the `src` field
 If there is no `src` field, you have two options:
 1) Request information on this ID from hosts that your launcher knows of.
 2) Throw a warning to the user, suggesting that they need to download the project, but the launcher cannot automatically install it.
+
+### Reasoning for optional `src` field
+
+You might think having an optional `src` field is stupid, as it doesn't tell a launcher where to get a dependency. But there is a valid reason for it. Some dependencies cannot be represented in MODIP format at all, due to legal, technical, or other reasons. The optional `src` field allows developers to indicate that a dependency is needed, but due to any number of reasons it cannot be provided. 
+
+This is better than simply ommitting the dependency altogether, as it gives a launcher the opportunity to notify the user about the dependency, rather than missing it.
+
 ---
 
 ## Implementing Conditions

--- a/format_implementing.md
+++ b/format_implementing.md
@@ -22,11 +22,28 @@ If there is no `src` field, you have two options:
 1) Request information on this ID from hosts that your launcher knows of.
 2) Throw a warning to the user, suggesting that they need to download the project, but the launcher cannot automatically install it.
 
+
 ### Reasoning for optional `src` field
 
 You might think having an optional `src` field is stupid, as it doesn't tell a launcher where to get a dependency. But there is a valid reason for it. Some dependencies cannot be represented in MODIP format at all, due to legal, technical, or other reasons. The optional `src` field allows developers to indicate that a dependency is needed, but due to any number of reasons it cannot be provided. 
 
 This is better than simply ommitting the dependency altogether, as it gives a launcher the opportunity to notify the user about the dependency, rather than missing it.
+
+### Example
+
+In the below example, a launcher should display a message indicating that `non-modip-dependency` cannot be automatically downloaded.
+```json
+"dependencies": [
+  {
+    "id": "non-modip-dependency",
+    "name": "Non-MODIP Dependency",
+    "version": "1.0.0",
+    // notice: no `src` field
+  }
+]
+```
+
+
 
 ---
 

--- a/format_implementing.md
+++ b/format_implementing.md
@@ -16,16 +16,11 @@ Framework IDs MUST be prefixed with `framework-`, so launchers can tell if a pro
 
 When a user downloads a project using a launcher, it's important to download its required dependencies. Launchers should combine the version dependencies with the file dependencies in order to create a full dependency list.
 
-For the purposes of this section, the term "the host" refers to the service a launcher is using in order to download projects, such as Diluv or Modrinth.
+When looking at a dependency, the first thing to do is check for the `src` field. If the `src` field exists, then the mod has external MODIP metadata. Process the metadata for that dependency from the `src` field.
 
-If a dependency's ID is `minecraft`, then it's the required Minecraft version. Implementation of where to obtain Minecraft metadata is up to the developer of a launcher. Launchers may download metadata from the host, from Mojang directly, or from another service.
-
-If a dependency's ID is not `minecraft`, then it's a required project.
-
-**TODO: Special case IDs may be removed.**
-
-If a dependency has the `src` field, it means that at that specified URL is full metadata about this dependency. Launchers should check here first if it's specified. If the URL does not serve a suitable result, or there is no `src` field, launchers should then ask the host of the parent for a project matching the same ID. If at this point the launcher still hasn't found any metadata for the project, the launcher may choose to ask another host that it knows of for a project with the same ID, or it may choose to fail and warn the user.
-
+If there is no `src` field, you have two options:
+1) Request information on this ID from hosts that your launcher knows of.
+2) Throw a warning to the user, suggesting that they need to download the project, but the launcher cannot automatically install it.
 ---
 
 ## Implementing Conditions

--- a/format_spec.md
+++ b/format_spec.md
@@ -300,56 +300,6 @@ This lists every version of Minecraft that this version of the project is known 
 
 ---
 
-### `dependencies` (optional)
-
-This field MUST be an array containing dependency objects.
-
-Dependency objects contain the following fields.
-
-##### `id`
-
-The ID of the required dependency. If this project is a Framework, it MUST be one of the values listed in **format_values.md** for Framework IDs. Hosts serving Framework metadata MUST use these standardized IDs.
-
-##### `allowed` (optional)
-
-Same as `version.allowed` except for this dependency.
-
-##### `required`
-
-This field is a boolean that indicates whether a dependency is required in order for the Project requiring it to function properly. **MAY be a condition.**
-
-##### `version`
-
-This field MUST be either an Array or String. If this field is an array, it MUST contain a list of compatible versions. If this field is a String, it MUST contain a Semantic Versioning comparison String. An example of a comparison string is `>= 25.0.219`.
-
-##### `src` (optional)
-
-This specifies where information about this dependency can be acquired. This field is *not* required as MODIP metadata for everything cannot be provided. 
-
-If this field is provided, it MUST contain either a String containing a URL that links to full metadata about the dependency, or it can be an object which fully complies with the MODIP project spec.
-For example, both 
-
-```jsonc
-"src": "https://example.com/dependency.modip.json"
-```
-and 
-```jsonc
-"src": {
-  "id": "dependency-id",
-  "name": "My Dependency"
-  // you get the idea
-}
-```
-are valid.
-
-A dependencies implementation guide for launchers is available in **format_implementing.md**.
-
-##### `installation`
-
-The installation script for this version. For details about installation scripts, see `install_script.md`.
-
----
-
 ### `files`
 
 This field contains the downloadable files of a Version. It MUST be an array of File Objects.
@@ -366,10 +316,6 @@ An SHA256 checksum of the file. This may be used by launchers in order to verify
 ##### `rel`
 
 The relation of this file. Possible values for this field are available in **format_values.md**. The values of this field CAN be present in multiple files. For example, a version can have a file for both the Forge and Fabric modloaders, and both of those files can have the `rel` field set to `primary`.
-
-##### `dependencies` (optional)
-
-This field MUST conform to the same specification as the Version's dependencies. BOTH a File and Version can have dependencies.
 
 ##### `downloads`
 

--- a/format_spec.md
+++ b/format_spec.md
@@ -287,6 +287,7 @@ The changelog of this version. The changelog MAY contain Formatted Text. It foll
 ### `allowed` (optional)
 
 Whether or not this version is allowed to be installed, based on the condition. **This field MUST be a condition, with a boolean value**
+
 ---
 
 ### `dependencies` (optional)
@@ -313,11 +314,12 @@ This field MUST be either an Array or String. If this field is an array, it MUST
 
 ##### `src` (optional)
 
-This specifies where information about this dependency can be acquired, but it's not always required. If the metadata of the parent project is being served from a host, then this field is not required and clients can lookup the ID at the host. For example, if I request metadata about a project from Modrinth and there is a dependency, "my-dependency", then I should call Modrinth's API in order to find out more about that dependency.
+This specifies where information about this dependency can be acquired. This field is *not* required as MODIP metadata for everything cannot be provided. 
 
-But it some cases, that's either not possible or impractical, which is where the `src` field comes in. This field MUST contain either a String containing a URL that links to full metadata about the dependency, or it can be an object which fully complies with the MODIP project spec.
+If this field is provided, it MUST contain either a String containing a URL that links to full metadata about the dependency, or it can be an object which fully complies with the MODIP project spec.
 For example, both 
-```
+
+```jsonc
 "src": "https://example.com/dependency.modip.json"
 ```
 and 
@@ -329,11 +331,6 @@ and
 }
 ```
 are valid.
-
-*TODO: Change Minecraft's dependency status? Remove special-case dependencies?*
-
-The required Minecraft Version also MUST be stored as a dependency. It's `id` value MUST be set to `minecraft`. It also MUST not contain the `required` field, as Minecraft is not an optional component.
-A dependencies implementation guide for launchers is available in **format_implementing.md**.
 
 ##### `installation`
 


### PR DESCRIPTION
Controversial! Allows dependencies with no MODIP metadata to exist. Somewhat related to #12.

Checklist:
- [X] Update spec
- [X] Update implementation guide
- [x] Provide full examples
- [x] Section providing full reasoning as to why this exists
