### PR TITLE
Fix data uri spec

### DIFF
--- a/format_spec.md
+++ b/format_spec.md
@@ -87,7 +87,7 @@ There is no difference between embedded videos and images, as they both display 
 
 The `src` field is valid for both `video` and `image`. It contains a direct URI to either a playable video file or an image file. It is RECOMMENDED for images to be in the WebP or PNG formats, and it is RECOMMENDED for videos to be in the WebM format. Recommended video codecs include VP9 and AV1.
 
-Base64 encoded images, which are typically prefixed with `data:base64` are NOT RECOMMENDED, however they CAN be present. If a Base64 encoded image is present, it MUST be prefixed with `data:base64`.
+`data` URIs are allowed, but are not recommended because they increase the file size substantially.
 
 **`embed` and `src` are conflicting fields and both fields CANNOT be present in the same Media Item.**
 


### PR DESCRIPTION
Base64 data URIs don't actually start with `data:base64`. It should actually be `data:;base64,` or `data:image/jpeg;base64,` (for example). But that's already an Internet standard and we don't need to repeat it here.